### PR TITLE
Add trim and replicate to logicalpath endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ foreach(API_NAME ${API_SERVER_NAMES})
 
     target_include_directories(
         ${EXECUTABLE_NAME}
-	PRIVATE
+        PRIVATE
         irods_specific_implementation
         jwt-cpp
         model

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ foreach(API_NAME ${API_SERVER_NAMES})
 
     target_include_directories(
         ${EXECUTABLE_NAME}
-        PRIVATE
+	PRIVATE
         irods_specific_implementation
         jwt-cpp
         model

--- a/README.md
+++ b/README.md
@@ -554,6 +554,43 @@ JSON formatted Zone Report
 }
 ```
 
+### /logicalpath/replicate
+Replicates a data object into some resource
+
+**Method**: POST
+
+**Parameters**:
+- all: If selected, updates all stale copies.
+- recursive:  Required to replicate a collection. Replicates the whole subtree. Does nothing if used on a data object.
+- thread-count: The number of threads to use for replication.
+- replica-number: Specifies the particular replicate to copy from. Typically not needed.
+- dst-resource: Resource to which to replicate the data object or collection.
+- logical-path: The logical path of the data object or collection to replicate.
+
+**Example CURL command**:
+```
+export TARGET_PATH=/tempZone/home/rods/hello.cpp
+curl -X POST -H "Authorization: ${TOKEN}" 'http://localhost/irods-rest/0.9.1/logicalpath/replicate?logical-path=$TARGET_PATH'
+```
+
+### /logicalpath/trim
+
+**Method**: DELETE
+**Parameters**:
+- recursive: Required to trim a collection. Trims the whole subtree. Does nothing if used on a data object.
+- dryrun: If set, no copy will actually be trimmed.
+- minimum-age-in-minutes: The minimum age in minutes foe a data object to be a candidate for trimmed. If a data object is younger, nothing will happen to it.
+- minimum-number-of-remaining-replicas: The minimum number of copies to leave after trimming. Defaults to 2.
+- replica-number: Determines the replica to trim.
+- src-resource: If specified, only replicas on this resource will be candidates for trimming.
+- admin-mode: Required for an admin to trim replicas of other users' data objects.
+
+Note that the `/admin` endpoint already exposes the ability to make
+or remove resources, in addition to other resource-related operations.
+
+**Returns**
+Nothing on success.
+
 ## Running test suite
 
 The test suite for this repository is heavily tied to the iRODS server's python test suite and affiliated libraries. As such, an iRODS server is required to be running on the same machine as the REST client in order to run the python tests.

--- a/README.md
+++ b/README.md
@@ -368,7 +368,46 @@ Renames a data object or collection
 
 **Example CURL command**
 ```
-curl -X DELETE -H "Authorization: ${TOKEN}" "http://localhost:80/irods-rest/0.9.2/logicalpath/rename?src=/tempZone/home/rods/hello&dst=/tempZone/home/rods/goodbye"
+curl -X POST -H "Authorization: ${TOKEN}" "http://localhost:80/irods-rest/0.9.2/logicalpath/rename?src=/tempZone/home/rods/hello&dst=/tempZone/home/rods/goodbye"
+```
+
+**Returns**
+Nothing on success.
+
+### /logicalpath/replicate
+Replicates a data object into some resource
+
+**Method**: POST
+
+**Parameters**:
+  - all: If selected, updates all stale copies.
+  - recursive:  Required to replicate a collection. Replicates the whole subtree. Does nothing if used on a data object.
+  - thread-count: The number of threads to use for replication.
+  - replica-number: Specifies the particular replicate to copy from. Typically not needed.
+  - dst-resource: Resource to which to replicate the data object or collection.
+  - src-resource: Resource from which to replicate the data object or collection.
+  - logical-path: The logical path of the data object or collection to replicate.
+  - admin-mode: Required for an admin to replicate other users' data objects.
+
+**Example CURL command**:
+```
+curl -X POST -H "Authorization: ${TOKEN}" 'http://localhost/irods-rest/0.9.2/logicalpath/replicate?logical-path=/tempZone/home/rods/hello.cpp&dst-resource=ufs0'
+```
+
+### /logicalpath/trim
+
+**Method**: POST
+**Parameters**:
+  - recursive: Required to trim a collection. Trims the whole subtree. Does nothing if used on a data object.
+  - minimum-age-in-minutes: The minimum age in minutes foe a data object to be a candidate for trimmed. If a data object is younger, nothing will happen to it.
+  - minimum-number-of-remaining-replicas: The minimum number of copies to leave after trimming. Defaults to 2.
+  - replica-number: Determines the replica to trim.
+  - src-resource: If specified, only replicas on this resource will be candidates for trimming.
+  - admin-mode: Required for an admin to trim replicas of other users' data objects.
+
+**Example CURL command**:
+```
+curl -X POST -H "Authorization: ${TOKEN}" 'http://localhost/irods-rest/0.9.2/logicalpath/trim?logical-path=/tempZone/home/rods/foo&src-resource=ufs0'
 ```
 
 **Returns**
@@ -553,43 +592,6 @@ JSON formatted Zone Report
     }]
 }
 ```
-
-### /logicalpath/replicate
-Replicates a data object into some resource
-
-**Method**: POST
-
-**Parameters**:
-- all: If selected, updates all stale copies.
-- recursive:  Required to replicate a collection. Replicates the whole subtree. Does nothing if used on a data object.
-- thread-count: The number of threads to use for replication.
-- replica-number: Specifies the particular replicate to copy from. Typically not needed.
-- dst-resource: Resource to which to replicate the data object or collection.
-- logical-path: The logical path of the data object or collection to replicate.
-
-**Example CURL command**:
-```
-export TARGET_PATH=/tempZone/home/rods/hello.cpp
-curl -X POST -H "Authorization: ${TOKEN}" 'http://localhost/irods-rest/0.9.1/logicalpath/replicate?logical-path=$TARGET_PATH'
-```
-
-### /logicalpath/trim
-
-**Method**: DELETE
-**Parameters**:
-- recursive: Required to trim a collection. Trims the whole subtree. Does nothing if used on a data object.
-- dryrun: If set, no copy will actually be trimmed.
-- minimum-age-in-minutes: The minimum age in minutes foe a data object to be a candidate for trimmed. If a data object is younger, nothing will happen to it.
-- minimum-number-of-remaining-replicas: The minimum number of copies to leave after trimming. Defaults to 2.
-- replica-number: Determines the replica to trim.
-- src-resource: If specified, only replicas on this resource will be candidates for trimming.
-- admin-mode: Required for an admin to trim replicas of other users' data objects.
-
-Note that the `/admin` endpoint already exposes the ability to make
-or remove resources, in addition to other resource-related operations.
-
-**Returns**
-Nothing on success.
 
 ## Running test suite
 

--- a/api/LogicalPathApi.cpp
+++ b/api/LogicalPathApi.cpp
@@ -4,72 +4,89 @@
 
 #include <spdlog/spdlog.h>
 
-namespace io::swagger::server::api
+namespace io::swagger::server::api {
+using namespace io::swagger::server::model;
+
+LogicalPathApi::LogicalPathApi(Pistache::Address addr)
+    : httpEndpoint(std::make_shared<Pistache::Http::Endpoint>(addr))
 {
-    using namespace io::swagger::server::model;
+}
 
-    LogicalPathApi::LogicalPathApi(Pistache::Address addr)
-        : httpEndpoint(std::make_shared<Pistache::Http::Endpoint>(addr))
-    {
+void LogicalPathApi::init(size_t thr = 2) {
+    auto opts = Pistache::Http::Endpoint::options()
+        .threads(thr);
+    httpEndpoint->init(opts);
+    setupRoutes();
+}
+
+void LogicalPathApi::start() {
+    httpEndpoint->setHandler(router.handler());
+    httpEndpoint->serve();
+}
+
+void LogicalPathApi::shutdown() {
+    httpEndpoint->shutdown();
+}
+
+void LogicalPathApi::setupRoutes() {
+    using namespace Pistache::Rest;
+
+    Routes::Delete(router, irods::rest::base_url + "/logicalpath", Routes::bind(&LogicalPathApi::delete_handler, this));
+    Routes::Post(router, irods::rest::base_url + "/logicalpath/rename", Routes::bind(&LogicalPathApi::rename_handler, this));
+    Routes::Delete(router, irods::rest::base_url + "/logicalpath/trim", Routes::bind(&LogicalPathApi::trim_handler, this));
+    Routes::Post(router, irods::rest::base_url + "/logicalpath/repl", Routes::bind(&LogicalPathApi::replicate_handler, this));
+
+    // Default handler, called when a route is not found
+    router.addCustomHandler(Routes::bind(&LogicalPathApi::default_handler, this));
+}
+
+void LogicalPathApi::rename_handler(const Pistache::Rest::Request& request,
+                       Pistache::Http::ResponseWriter response)
+{
+    try {
+        this->rename_handler_impl(request, response);
     }
-
-    void LogicalPathApi::init(size_t thr = 2)
-    {
-        auto opts = Pistache::Http::Endpoint::options().threads(thr);
-        httpEndpoint->init(opts);
-        setupRoutes();
+    catch (const std::runtime_error& e){
+        response.send(Pistache::Http::Code::Bad_Request, e.what());
     }
+}
 
-    void LogicalPathApi::start()
-    {
-        httpEndpoint->setHandler(router.handler());
-        httpEndpoint->serve();
+void LogicalPathApi::delete_handler(const Pistache::Rest::Request& request,
+                       Pistache::Http::ResponseWriter response)
+{
+    try {
+        this->delete_handler_impl(request, response);
     }
-
-    void LogicalPathApi::shutdown()
-    {
-        httpEndpoint->shutdown();
+    catch (const std::runtime_error& e){
+        response.send(Pistache::Http::Code::Bad_Request, e.what());
     }
+}
 
-    void LogicalPathApi::setupRoutes()
-    {
-        using namespace Pistache::Rest;
-
-        Routes::Delete(router,
-                       irods::rest::base_url + "/logicalpath",
-                       Routes::bind(&LogicalPathApi::delete_handler, this));
-
-        Routes::Post(router,
-                     irods::rest::base_url + "/logicalpath/rename",
-                     Routes::bind(&LogicalPathApi::rename_handler, this));
-
-        // Default handler, called when a route is not found
-        router.addCustomHandler(Routes::bind(&LogicalPathApi::default_handler, this));
+void LogicalPathApi::replicate_handler(const Pistache::Rest::Request& request,
+                       Pistache::Http::ResponseWriter response)
+{
+    try {
+        this->replicate_handler_impl(request, response);
     }
-
-    void LogicalPathApi::rename_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
-    {
-        try {
-            this->rename_handler_impl(request, response);
-        }
-        catch (const std::runtime_error& e) {
-            response.send(Pistache::Http::Code::Bad_Request, e.what());
-        }
+    catch (const std::runtime_error& e){
+        response.send(Pistache::Http::Code::Bad_Request, e.what());
     }
+}
 
-    void LogicalPathApi::delete_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
-    {
-        try {
-            this->delete_handler_impl(request, response);
-        }
-        catch (const std::runtime_error& e) {
-            response.send(Pistache::Http::Code::Bad_Request, e.what());
-        }
+void LogicalPathApi::trim_handler(const Pistache::Rest::Request& request,
+                       Pistache::Http::ResponseWriter response)
+{
+    try {
+        this->trim_handler_impl(request, response);
     }
+    catch (const std::runtime_error& e){
+        response.send(Pistache::Http::Code::Bad_Request, e.what());
+    }
+}
+void LogicalPathApi::default_handler(const Pistache::Rest::Request& request,
+                               Pistache::Http::ResponseWriter response)
+{
+    response.send(Pistache::Http::Code::Not_Found, "The requested Logicalpath method does not exist");
+}
 
-    void LogicalPathApi::default_handler(const Pistache::Rest::Request& request,
-                                         Pistache::Http::ResponseWriter response)
-    {
-        response.send(Pistache::Http::Code::Not_Found, "The requested Logicalpath method does not exist");
-    }
-} // namespace io::swagger::server::api
+}

--- a/api/LogicalPathApi.cpp
+++ b/api/LogicalPathApi.cpp
@@ -39,11 +39,11 @@ namespace io::swagger::server::api
             router, irods::rest::base_url + "/logicalpath", Routes::bind(&LogicalPathApi::delete_handler, this));
         Routes::Post(
             router, irods::rest::base_url + "/logicalpath/rename", Routes::bind(&LogicalPathApi::rename_handler, this));
-        Routes::Delete(
+        Routes::Post(
             router, irods::rest::base_url + "/logicalpath/trim", Routes::bind(&LogicalPathApi::trim_handler, this));
         Routes::Post(
             router,
-            irods::rest::base_url + "/logicalpath/repl",
+            irods::rest::base_url + "/logicalpath/replicate",
             Routes::bind(&LogicalPathApi::replicate_handler, this));
 
         // Default handler, called when a route is not found

--- a/api/LogicalPathApi.cpp
+++ b/api/LogicalPathApi.cpp
@@ -4,89 +4,98 @@
 
 #include <spdlog/spdlog.h>
 
-namespace io::swagger::server::api {
-using namespace io::swagger::server::model;
-
-LogicalPathApi::LogicalPathApi(Pistache::Address addr)
-    : httpEndpoint(std::make_shared<Pistache::Http::Endpoint>(addr))
+namespace io::swagger::server::api
 {
-}
+    using namespace io::swagger::server::model;
 
-void LogicalPathApi::init(size_t thr = 2) {
-    auto opts = Pistache::Http::Endpoint::options()
-        .threads(thr);
-    httpEndpoint->init(opts);
-    setupRoutes();
-}
-
-void LogicalPathApi::start() {
-    httpEndpoint->setHandler(router.handler());
-    httpEndpoint->serve();
-}
-
-void LogicalPathApi::shutdown() {
-    httpEndpoint->shutdown();
-}
-
-void LogicalPathApi::setupRoutes() {
-    using namespace Pistache::Rest;
-
-    Routes::Delete(router, irods::rest::base_url + "/logicalpath", Routes::bind(&LogicalPathApi::delete_handler, this));
-    Routes::Post(router, irods::rest::base_url + "/logicalpath/rename", Routes::bind(&LogicalPathApi::rename_handler, this));
-    Routes::Delete(router, irods::rest::base_url + "/logicalpath/trim", Routes::bind(&LogicalPathApi::trim_handler, this));
-    Routes::Post(router, irods::rest::base_url + "/logicalpath/repl", Routes::bind(&LogicalPathApi::replicate_handler, this));
-
-    // Default handler, called when a route is not found
-    router.addCustomHandler(Routes::bind(&LogicalPathApi::default_handler, this));
-}
-
-void LogicalPathApi::rename_handler(const Pistache::Rest::Request& request,
-                       Pistache::Http::ResponseWriter response)
-{
-    try {
-        this->rename_handler_impl(request, response);
+    LogicalPathApi::LogicalPathApi(Pistache::Address addr)
+        : httpEndpoint(std::make_shared<Pistache::Http::Endpoint>(addr))
+    {
     }
-    catch (const std::runtime_error& e){
-        response.send(Pistache::Http::Code::Bad_Request, e.what());
-    }
-}
 
-void LogicalPathApi::delete_handler(const Pistache::Rest::Request& request,
-                       Pistache::Http::ResponseWriter response)
-{
-    try {
-        this->delete_handler_impl(request, response);
+    void LogicalPathApi::init(size_t thr = 2)
+    {
+        auto opts = Pistache::Http::Endpoint::options().threads(thr);
+        httpEndpoint->init(opts);
+        setupRoutes();
     }
-    catch (const std::runtime_error& e){
-        response.send(Pistache::Http::Code::Bad_Request, e.what());
-    }
-}
 
-void LogicalPathApi::replicate_handler(const Pistache::Rest::Request& request,
-                       Pistache::Http::ResponseWriter response)
-{
-    try {
-        this->replicate_handler_impl(request, response);
+    void LogicalPathApi::start()
+    {
+        httpEndpoint->setHandler(router.handler());
+        httpEndpoint->serve();
     }
-    catch (const std::runtime_error& e){
-        response.send(Pistache::Http::Code::Bad_Request, e.what());
-    }
-}
 
-void LogicalPathApi::trim_handler(const Pistache::Rest::Request& request,
-                       Pistache::Http::ResponseWriter response)
-{
-    try {
-        this->trim_handler_impl(request, response);
+    void LogicalPathApi::shutdown()
+    {
+        httpEndpoint->shutdown();
     }
-    catch (const std::runtime_error& e){
-        response.send(Pistache::Http::Code::Bad_Request, e.what());
-    }
-}
-void LogicalPathApi::default_handler(const Pistache::Rest::Request& request,
-                               Pistache::Http::ResponseWriter response)
-{
-    response.send(Pistache::Http::Code::Not_Found, "The requested Logicalpath method does not exist");
-}
 
-}
+    void LogicalPathApi::setupRoutes()
+    {
+        using namespace Pistache::Rest;
+
+        Routes::Delete(
+            router, irods::rest::base_url + "/logicalpath", Routes::bind(&LogicalPathApi::delete_handler, this));
+        Routes::Post(
+            router, irods::rest::base_url + "/logicalpath/rename", Routes::bind(&LogicalPathApi::rename_handler, this));
+        Routes::Delete(
+            router, irods::rest::base_url + "/logicalpath/trim", Routes::bind(&LogicalPathApi::trim_handler, this));
+        Routes::Post(
+            router,
+            irods::rest::base_url + "/logicalpath/repl",
+            Routes::bind(&LogicalPathApi::replicate_handler, this));
+
+        // Default handler, called when a route is not found
+        router.addCustomHandler(Routes::bind(&LogicalPathApi::default_handler, this));
+    }
+
+    void LogicalPathApi::rename_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
+    {
+        try {
+            this->rename_handler_impl(request, response);
+        }
+        catch (const std::runtime_error& e) {
+            response.send(Pistache::Http::Code::Bad_Request, e.what());
+        }
+    }
+
+    void LogicalPathApi::delete_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
+    {
+        try {
+            this->delete_handler_impl(request, response);
+        }
+        catch (const std::runtime_error& e) {
+            response.send(Pistache::Http::Code::Bad_Request, e.what());
+        }
+    }
+
+    void LogicalPathApi::replicate_handler(
+        const Pistache::Rest::Request& request,
+        Pistache::Http::ResponseWriter response)
+    {
+        try {
+            this->replicate_handler_impl(request, response);
+        }
+        catch (const std::runtime_error& e) {
+            response.send(Pistache::Http::Code::Bad_Request, e.what());
+        }
+    }
+
+    void LogicalPathApi::trim_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
+    {
+        try {
+            this->trim_handler_impl(request, response);
+        }
+        catch (const std::runtime_error& e) {
+            response.send(Pistache::Http::Code::Bad_Request, e.what());
+        }
+    }
+    void LogicalPathApi::default_handler(
+        const Pistache::Rest::Request& request,
+        Pistache::Http::ResponseWriter response)
+    {
+        response.send(Pistache::Http::Code::Not_Found, "The requested Logicalpath method does not exist");
+    }
+
+} //namespace io::swagger::server::api

--- a/api/LogicalPathApi.h
+++ b/api/LogicalPathApi.h
@@ -19,7 +19,7 @@ namespace io::swagger::server::api
     {
     public:
         LogicalPathApi(Pistache::Address addr);
-        virtual ~LogicalPathApi() {};
+        virtual ~LogicalPathApi(){};
 
         void init(size_t thr);
         void start();
@@ -28,26 +28,25 @@ namespace io::swagger::server::api
     private:
         void setupRoutes();
 
-        void default_handler(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter response);
+        void default_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
 
-        void delete_handler(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter response);
-        void rename_handler(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter response);
-        void trim_handler(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter response);
-        void replicate_handler(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter response);
+        void delete_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+        void rename_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+        void trim_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+        void replicate_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
 
-        virtual void delete_handler_impl(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter& response) = 0;
-        virtual void rename_handler_impl(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter& response) = 0;
-        virtual void trim_handler_impl(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter& response) = 0;
-        virtual void replicate_handler_impl(const Pistache::Rest::Request& request,
-                             Pistache::Http::ResponseWriter& response) = 0;
+        virtual void delete_handler_impl(
+            const Pistache::Rest::Request& request,
+            Pistache::Http::ResponseWriter& response) = 0;
+        virtual void rename_handler_impl(
+            const Pistache::Rest::Request& request,
+            Pistache::Http::ResponseWriter& response) = 0;
+        virtual void trim_handler_impl(
+            const Pistache::Rest::Request& request,
+            Pistache::Http::ResponseWriter& response) = 0;
+        virtual void replicate_handler_impl(
+            const Pistache::Rest::Request& request,
+            Pistache::Http::ResponseWriter& response) = 0;
 
         std::shared_ptr<Pistache::Http::Endpoint> httpEndpoint;
         Pistache::Rest::Router router;

--- a/api/LogicalPathApi.h
+++ b/api/LogicalPathApi.h
@@ -19,7 +19,7 @@ namespace io::swagger::server::api
     {
     public:
         LogicalPathApi(Pistache::Address addr);
-        virtual ~LogicalPathApi(){};
+        virtual ~LogicalPathApi() {};
 
         void init(size_t thr);
         void start();
@@ -28,17 +28,26 @@ namespace io::swagger::server::api
     private:
         void setupRoutes();
 
-        void default_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+        void default_handler(const Pistache::Rest::Request& request,
+                             Pistache::Http::ResponseWriter response);
 
-        void delete_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
-
-        void rename_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
+        void delete_handler(const Pistache::Rest::Request& request,
+                             Pistache::Http::ResponseWriter response);
+        void rename_handler(const Pistache::Rest::Request& request,
+                             Pistache::Http::ResponseWriter response);
+        void trim_handler(const Pistache::Rest::Request& request,
+                             Pistache::Http::ResponseWriter response);
+        void replicate_handler(const Pistache::Rest::Request& request,
+                             Pistache::Http::ResponseWriter response);
 
         virtual void delete_handler_impl(const Pistache::Rest::Request& request,
-                                         Pistache::Http::ResponseWriter& response) = 0;
-
+                             Pistache::Http::ResponseWriter& response) = 0;
         virtual void rename_handler_impl(const Pistache::Rest::Request& request,
-                                         Pistache::Http::ResponseWriter& response) = 0;
+                             Pistache::Http::ResponseWriter& response) = 0;
+        virtual void trim_handler_impl(const Pistache::Rest::Request& request,
+                             Pistache::Http::ResponseWriter& response) = 0;
+        virtual void replicate_handler_impl(const Pistache::Rest::Request& request,
+                             Pistache::Http::ResponseWriter& response) = 0;
 
         std::shared_ptr<Pistache::Http::Endpoint> httpEndpoint;
         Pistache::Rest::Router router;

--- a/docker/runner/entrypoint.sh
+++ b/docker/runner/entrypoint.sh
@@ -1,5 +1,7 @@
 #! /bin/bash -e
 
+/etc/init.d/rsyslog start
+
 /etc/init.d/irods_client_rest_cpp start
 
 # sleep forever

--- a/docker/runner/irods_client_rest_cpp.Dockerfile
+++ b/docker/runner/irods_client_rest_cpp.Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         apt-transport-https \
         gnupg \
         lsb-release \
+        rsyslog \
         sudo \
         wget \
     && \
@@ -28,6 +29,10 @@ RUN apt-get update && \
     apt-get install -fy --allow-downgrades && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Use the default rsyslog configuration for this image
+RUN cp /etc/irods_client_rest_cpp/irods_client_rest_cpp.conf.rsyslog /etc/rsyslog.d/00-irods_client_rest_cpp.conf && \
+    cp /etc/irods_client_rest_cpp/irods_client_rest_cpp.logrotate /etc/logrotate.d/irods_client_rest_cpp
 
 COPY entrypoint.sh /
 RUN chmod u+x /entrypoint.sh

--- a/docker/runner/irods_client_rest_cpp.json
+++ b/docker/runner/irods_client_rest_cpp.json
@@ -5,7 +5,8 @@
         "port": 1247,
         "ssl_negotiation_policy": "CS_NEG_REFUSE",
         "rodsadmin_username": "rods",
-        "rodsadmin_password": "rods"
+        "rodsadmin_password": "rods",
+        "default_resource": "demoResc"
     },
     "rest_api": {
         "jwt_signing_key": "TEMPORARY_SIGNING_KEY",

--- a/docker/tester/entrypoint.sh
+++ b/docker/tester/entrypoint.sh
@@ -14,6 +14,12 @@ su - postgres -c 'psql -f /db_commands.txt'
 
 python3 /var/lib/irods/scripts/setup_irods.py < /var/lib/irods/packaging/localhost_setup_postgres.input
 
+# Use the default rsyslog configuration for this image
+RUN cp /etc/irods_client_rest_cpp/irods_client_rest_cpp.conf.rsyslog /etc/rsyslog.d/00-irods_client_rest_cpp.conf && \
+    cp /etc/irods_client_rest_cpp/irods_client_rest_cpp.logrotate /etc/logrotate.d/irods_client_rest_cpp
+
+/etc/init.d/rsyslog stop && /etc/init.d/rsyslog start
+
 /etc/init.d/irods_client_rest_cpp start
 
 # TODO: Should this be the CMD rather than part of the ENTRYPOINT?

--- a/docker/tester/irods_client_rest_cpp.Dockerfile
+++ b/docker/tester/irods_client_rest_cpp.Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         apt-transport-https \
         gnupg \
         lsb-release \
+        rsyslog \
         sudo \
         wget \
     && \

--- a/docker/tester/irods_client_rest_cpp.json
+++ b/docker/tester/irods_client_rest_cpp.json
@@ -5,7 +5,8 @@
         "port": 1247,
         "ssl_negotiation_policy": "CS_NEG_REFUSE",
         "rodsadmin_username": "rods",
-        "rodsadmin_password": "rods"
+        "rodsadmin_password": "rods",
+        "default_resource": "demoResc"
     },
     "rest_api": {
         "jwt_signing_key": "TEMPORARY_SIGNING_KEY",

--- a/impl/LogicalPathApiImpl.cpp
+++ b/impl/LogicalPathApiImpl.cpp
@@ -32,8 +32,9 @@ namespace io::swagger::server::api
         irods::rest::handle_request(irods_logic, request, response);
     }
 
-    void LogicalPathApiImpl::trim_handler_impl(const Pistache::Rest::Request& request,
-                                        Pistache::Http::ResponseWriter& response )
+    void LogicalPathApiImpl::trim_handler_impl(
+        const Pistache::Rest::Request& request,
+        Pistache::Http::ResponseWriter& response)
     {
         const auto irods_logic = [this](const Pistache::Rest::Request& _req, Pistache::Http::ResponseWriter& _res) {
             return irods_logical_path_.trim_dispatcher(_req, _res);
@@ -41,8 +42,9 @@ namespace io::swagger::server::api
         irods::rest::handle_request(irods_logic, request, response);
     }
 
-    void LogicalPathApiImpl::replicate_handler_impl(const Pistache::Rest::Request& request,
-                                        Pistache::Http::ResponseWriter& response )
+    void LogicalPathApiImpl::replicate_handler_impl(
+        const Pistache::Rest::Request& request,
+        Pistache::Http::ResponseWriter& response)
     {
         const auto irods_logic = [this](const Pistache::Rest::Request& _req, Pistache::Http::ResponseWriter& _res) {
             return irods_logical_path_.replicate_dispatcher(_req, _res);

--- a/impl/LogicalPathApiImpl.cpp
+++ b/impl/LogicalPathApiImpl.cpp
@@ -31,4 +31,22 @@ namespace io::swagger::server::api
         };
         irods::rest::handle_request(irods_logic, request, response);
     }
+
+    void LogicalPathApiImpl::trim_handler_impl(const Pistache::Rest::Request& request,
+                                        Pistache::Http::ResponseWriter& response )
+    {
+        const auto irods_logic = [this](const Pistache::Rest::Request& _req, Pistache::Http::ResponseWriter& _res) {
+            return irods_logical_path_.trim_dispatcher(_req, _res);
+        };
+        irods::rest::handle_request(irods_logic, request, response);
+    }
+
+    void LogicalPathApiImpl::replicate_handler_impl(const Pistache::Rest::Request& request,
+                                        Pistache::Http::ResponseWriter& response )
+    {
+        const auto irods_logic = [this](const Pistache::Rest::Request& _req, Pistache::Http::ResponseWriter& _res) {
+            return irods_logical_path_.replicate_dispatcher(_req, _res);
+        };
+        irods::rest::handle_request(irods_logic, request, response);
+    }
 } // namespace io::swagger::server::api

--- a/impl/LogicalPathApiImpl.h
+++ b/impl/LogicalPathApiImpl.h
@@ -28,14 +28,14 @@ namespace io::swagger::server::api
         void rename_handler_impl(const Pistache::Rest::Request& request,
                                  Pistache::Http::ResponseWriter& response) override;
 
-        void delete_handler_impl(const Pistache::Rest::Request& request,
-                                       Pistache::Http::ResponseWriter& response) override;
+        void delete_handler_impl(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter& response)
+            override;
 
-        void trim_handler_impl(const Pistache::Rest::Request& request,
-                                          Pistache::Http::ResponseWriter& response) override;
+        void trim_handler_impl(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter& response)
+            override;
 
-        void replicate_handler_impl(const Pistache::Rest::Request& request,
-                                       Pistache::Http::ResponseWriter& response) override;
+        void replicate_handler_impl(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter& response)
+            override;
 
         irods::rest::logical_path irods_logical_path_;
     }; // class LogicalPathApiImpl

--- a/impl/LogicalPathApiImpl.h
+++ b/impl/LogicalPathApiImpl.h
@@ -29,7 +29,13 @@ namespace io::swagger::server::api
                                  Pistache::Http::ResponseWriter& response) override;
 
         void delete_handler_impl(const Pistache::Rest::Request& request,
-                                 Pistache::Http::ResponseWriter& response) override;
+                                       Pistache::Http::ResponseWriter& response) override;
+
+        void trim_handler_impl(const Pistache::Rest::Request& request,
+                                          Pistache::Http::ResponseWriter& response) override;
+
+        void replicate_handler_impl(const Pistache::Rest::Request& request,
+                                       Pistache::Http::ResponseWriter& response) override;
 
         irods::rest::logical_path irods_logical_path_;
     }; // class LogicalPathApiImpl

--- a/impl/ZoneReportApiImpl.h
+++ b/impl/ZoneReportApiImpl.h
@@ -13,7 +13,7 @@
 /*
 * ZoneReportApiImpl.h
 *
-* 
+*
 */
 
 #ifndef ZONE_REPORT_API_IMPL_H_

--- a/impl/ZoneReportApiImpl.h
+++ b/impl/ZoneReportApiImpl.h
@@ -11,10 +11,10 @@
 */
 
 /*
-* ZoneReportApiImpl.h
-*
-*
-*/
+ * ZoneReportApiImpl.h
+ *
+ *
+ */
 
 #ifndef ZONE_REPORT_API_IMPL_H_
 #define ZONE_REPORT_API_IMPL_H_

--- a/irods_specific_implementation/irods_rest_logical_path_api_implementation.h
+++ b/irods_specific_implementation/irods_rest_logical_path_api_implementation.h
@@ -8,14 +8,18 @@
 #include <irods/rodsErrorTable.h>
 #include <irods/irods_at_scope_exit.hpp>
 #include <irods/irods_query.hpp>
+#include <irods/key_value_proxy.hpp>
 
 #include <pistache/http_headers.h>
 #include <pistache/optional.h>
 #include <pistache/router.h>
 
+namespace fs = irods::experimental::filesystem;
+namespace fscli = irods::experimental::filesystem::client;
+
 namespace irods::rest
 {
-    const std::string service_name{"irods_rest_cpp_logicalpath_server"};
+    const std::string service_name { "irods_rest_cpp_logicalpath_server" };
 
     // this is contractually tied directly to the api implementation
     class logical_path : public api_base
@@ -102,8 +106,8 @@ namespace irods::rest
                 }
 
                 return std::make_tuple(Pistache::Http::Code::Ok, "");
-            }
-            catch (const fs::filesystem_error& e) {
+	    }
+	    catch (const fs::filesystem_error& e) {
                 error("Caught exception - [error_code={}] {}", e.code().value(), e.what());
                 return make_error_response(e.code().value(), e.what());
             }
@@ -115,10 +119,371 @@ namespace irods::rest
                 error("Caught exception - {}", e.what());
                 return make_error_response(SYS_INTERNAL_ERR, e.what());
             }
-            catch (...) {
-                error("Caught unknown exception");
-                return make_error_response(SYS_UNKNOWN_ERROR, "Unknown error occurred");
+	    catch (...){
+		error("Caught unknown exception.");
+		return make_error_response(SYS_UNKNOWN_ERROR, "Caught unknown exception");
+	    }
+	}
+
+        std::tuple<Pistache::Http::Code, std::string>
+        trim_dispatcher(const Pistache::Rest::Request& _request,
+                   Pistache::Http::ResponseWriter& _response)
+        {
+            try {
+              auto conn = get_connection(_request.headers().getRaw("authorization").value());
+              dataObjInp_t trim_input{};
+
+              bool is_collection = false;
+
+              setup_input_for_trim(
+                _request,
+                trim_input,
+                *conn(),
+                is_collection
+              );
+
+              int status;
+              if ( is_collection ) {
+
+                if ( ! is_set(_request.query().get("recursive").getOrElse("0")) ) {
+                    return make_error_response(
+                        USER_INCOMPATIBLE_PARAMS,
+                        "'recursive=1' required to trim a collection. Make sure you want to trim the whole sub-tree."
+                    );
+                }
+
+                for ( const auto& pathname : fscli::recursive_collection_iterator(*conn(), trim_input.objPath) ) {
+                    if ( fscli::is_data_object( fscli::status( *conn(), decode_url(pathname.path()) ) ) ) {
+                        strcpy(
+                            trim_input.objPath,
+                            pathname.path().c_str()
+                        );
+
+                        status = rcDataObjTrim(conn(), &trim_input);
+                        if ( status == SYS_NOT_ALLOWED ) {
+                            return make_error_response(status, "You have tried to trim a data object or collection you don't have permissions for.");
+                        }
+                        else if ( status == USER_INPUT_PATH_ERR ) {
+                            return make_error_response(status, "You tried to trim a path that doesn't seem to exist in this zone.");
+                        }
+                        else if ( status == USER_INCOMPATIBLE_PARAMS ) {
+                            return make_error_response(status, "You have specified two or more parameters for your trim operation which are incompatible with each other. See https://docs.irods.org/4.3.0/icommands/user/#itrim");
+                        }
+                        else if ( status == CAT_NO_ROWS_FOUND) {
+                            return make_error_response(status, "Could not find the logical path you entered. You may have passed an empty string.");
+                        }
+                        else if ( status < 0 ) {
+                            return make_error_response(status, "Client experienced an error processing your trim request. Please check the logs or notify your administrator.");
+                        }
+                    }
+                }
+              } else {
+	    	if ( fscli::is_data_object( fscli::status( *conn(), decode_url(trim_input.objPath) ) ) ) {
+		    status = rcDataObjTrim(conn(), &trim_input);
+		} else {
+		    return make_error_response(USER_INCOMPATIBLE_PARAMS, "Target is not a data object.");
+		}
+              }
+              if ( status == SYS_NOT_ALLOWED ) {
+                return  make_error_response(status, "You have tried to trim a data object or collection you don't have permissions for.");
+              }
+              else if ( status == USER_INPUT_PATH_ERR ) {
+                return make_error_response(status, "You tried to trim a path that doesn't seem to exist in this zone.");
+              }
+              else if ( status == USER_INCOMPATIBLE_PARAMS ) {
+                return make_error_response(status, "You have specified incompatible parameters for your trim operation.");
+              }
+	      else if ( status == CAT_NO_ROWS_FOUND) {
+                return make_error_response(status, "Could not find the logical path you entered. You may have passed an empty string.");
+              }
+              else if ( status < 0 ) {
+                return make_error_response(status, "Client experienced an error processing your trim request. Please check the logs or notify your administrator.");
+              }
+
+              return std::make_tuple(
+                Pistache::Http::Code::Ok,
+                ""
+              );
             }
+            catch (const irods::exception& e) {
+                error("Caught exception - [error_code={}] {}", e.code(), e.what());
+                return make_error_response(e.code(), e.what());
+            }
+            catch (const std::exception& e) {
+                error("Caught exception - {}", e.what());
+                return make_error_response(SYS_INVALID_INPUT_PARAM, e.what());
+            }
+	    catch (...){
+		error("Caught unknown exception.");
+		return make_error_response(SYS_UNKNOWN_ERROR, "Caught unknown exception");
+	    }
         }
+
+        std::tuple<Pistache::Http::Code, std::string>
+        replicate_dispatcher(const Pistache::Rest::Request& _request,
+                   Pistache::Http::ResponseWriter& _response)
+        {
+            try {
+              dataObjInp_t repl_input{};
+
+              auto conn = get_connection(_request.headers().getRaw("authorization").value());
+
+              bool is_collection = false;
+
+              setup_input_for_repl(
+                  repl_input,
+                  _request,
+                  *conn(),
+                  is_collection
+              );
+
+              int status;
+              const auto start_path = repl_input.objPath;
+              if ( is_collection ) {
+                if ( ! is_set(_request.query().get("recursive").getOrElse("")) )
+                {
+                    return std::make_tuple(
+                        Pistache::Http::Code::Bad_Request,
+                        "'recursive=1' required to replicate a collection. Make sure you want to replicate the whole sub-tree."
+                    );
+                }
+
+                for ( const auto& pathname : fscli::recursive_collection_iterator(*conn(), start_path) ) {
+                    if ( fscli::is_data_object(fscli::status(*conn(), decode_url(pathname.path()))) ) {
+			strcpy(
+			  repl_input.objPath,
+			  pathname.path().c_str()
+			);
+
+                        status = rcDataObjRepl(conn(), &repl_input);
+                        if ( status == SYS_INVALID_FILE_PATH ) {
+                            return make_error_response(status, "You passed an invalid path for replication. Make sure that you are giving an absolute path.");
+                        }
+                        else if ( status == SYS_NOT_ALLOWED ) {
+                            std::stringstream msg;
+                            msg << "You have tried to repl an object in a way that is not allowed.\n";
+                            msg << "Some possible causes are:\n";
+                            msg << "- You may have tried to replicate a non-good replica.\n";
+                            msg << "- The object you tried to replicate may have a checksum that wasn't verified.\n";
+                            msg << "- You may have tried to replicate a data object onto an already identical replica.\n";
+                            msg << "Please check for these issues and contact your administrator if the issue isn't resolved.\n";
+                            return make_error_response(SYS_NOT_ALLOWED, msg.str());
+                        }
+                        else if ( status == USER_INPUT_PATH_ERR ) {
+                            return make_error_response(status, "You tried to trim a path that doesn't seem to exist in this zone.");
+                        }
+                        else if ( status == USER_INCOMPATIBLE_PARAMS ) {
+                            return make_error_response(status, "You have specified two or more parameters for your trim operation which are incompatible with each other. See https://docs.irods.org/4.3.0/icommands/user/#itrim");
+                        }
+                        else if ( status < 0 ) {
+                            return make_error_response(status, "Client experienced an error processing your trim request. Please check the logs or notify your administrator.");
+                        }
+                    }
+                }
+              } else {
+                status = rcDataObjRepl(
+                    conn(),
+                    &repl_input
+                );
+                if ( status == SYS_INVALID_FILE_PATH ) {
+                    return make_error_response(status, "You passed an invalid path for replication. Make sure that you are giving an absolute path.");
+                }
+                else if ( status == USER_INPUT_PATH_ERR ) {
+                    return make_error_response(status, "You tried to trim a path that doesn't seem to exist in this zone.");
+                }
+                else if ( status == USER_INCOMPATIBLE_PARAMS ) {
+                    return make_error_response(status, "You have specified incompatible parameters for your trim operation.");
+                }
+                else if ( status == SYS_NOT_ALLOWED ) {
+                    std::stringstream msg;
+                    msg << "You have tried to repl an object in a way that is not allowed.\n";
+                    msg << "Some possible causes are:\n";
+                    msg << "- You may have tried to replicate a non-good replica.\n";
+                    msg << "- The object you tried to replicate may have a checksum that wasn't verified.\n";
+                    msg << "- You may have tried to replicate a data object onto an already identical replica.\n";
+                    msg << "Please check for these issues and contact your administrator if the issue isn't resolved.\n";
+                    return make_error_response(SYS_NOT_ALLOWED, msg.str());
+                }
+                else if ( status < 0 ) {
+                    return make_error_response(status, "Client experienced an error processing your trim request. Please check the logs or notify your administrator.");
+                }
+              }
+
+                return std::make_tuple(
+                    Pistache::Http::Code::Ok,
+                    ""
+                );
+            }
+	    catch (const fs::filesystem_error& e){
+		error("Caught exception - [error_code=]", e.code().value());
+		return make_error_response(e.code().value(), e.what());
+	    }
+            catch (const irods::exception& e) {
+                error("Caught exception - [error_code={}] {}", e.code(), e.what());
+                return make_error_response(e.code(), e.what());
+            }
+            catch (const std::exception& e) {
+                error("Caught exception - {}", e.what());
+                return make_error_response(SYS_INVALID_INPUT_PARAM, e.what());
+            }
+	    catch (...){
+		error("Caught unknown exception.");
+		return make_error_response(SYS_UNKNOWN_ERROR, "Caught unknown exception");
+	    }
+        }
+
+    private:
+        void setup_input_for_trim(
+                const Pistache::Http::Request& _request,
+                dataObjInp_t& trim_input,
+                rcComm_t& conn,
+                bool& is_collection
+            )
+        {
+              const auto _logical_path = _request.query().get("logical-path").getOrElse("");
+              is_collection = fscli::is_collection(
+                fscli::status(conn, decode_url(_logical_path))
+              );
+
+              // optional params
+              // ---------------
+              // Boolean
+              const auto _recursive      = _request.query().get("recursive").getOrElse("0");
+              // Boolean
+              const auto _dryrun         = _request.query().get("dryrun").getOrElse("");
+              // Integer
+              const auto _age            = _request.query().get("minimum-age-in-minutes").getOrElse("");
+              // Integer
+              const auto _num            = _request.query().get("minimum-number-of-remaining-replicas").getOrElse("");
+              // Integer
+              const auto _replica_number = _request.query().get("replica-number").getOrElse("");
+              // String
+              const auto _src_resc       = _request.query().get("src-rescource").getOrElse("");
+              // Boolean
+              const auto _admin          = _request.query().get("admin-mode").getOrElse("");
+
+	      // Set up key-value proxy
+	      irods::experimental::key_value_proxy kvp {trim_input.condInput};
+
+              if (is_set(_recursive)) {
+		kvp[RECURSIVE_OPR__KW] = "";
+              }
+
+              if (is_set(_admin)) {
+		kvp[ADMIN_KW] = "";
+              }
+
+              if (is_set(_dryrun)) {
+		kvp[DRYRUN_KW] = "";
+              }
+
+              rstrcpy(
+                trim_input.objPath,
+                _logical_path.c_str(),
+                MAX_NAME_LEN
+              );
+
+              if ( ! _num.empty() ) {
+		  kvp[COPIES_KW] = _num.c_str();
+              }
+
+              if ( ! _age.empty() ) {
+		  kvp[AGE_KW] = _age.c_str();
+              }
+
+              if ( ! _replica_number.empty() ) {
+		  kvp[REPL_NUM_KW] = _replica_number.c_str();
+              }
+
+              if ( ! _src_resc.empty() ) {
+		  kvp[RESC_NAME_KW] = _src_resc.c_str();
+              }
+        } // setup_input_for_trim
+
+        void setup_input_for_repl(
+            dataObjInp_t& _repl_input,
+            const Pistache::Http::Request& _request,
+            rcComm_t& _conn,
+            bool& _is_collection
+        ) {
+              rodsEnv myRodsEnv;
+              getRodsEnv(&myRodsEnv);
+
+              // Optional parameters
+              // Boolean parameters
+              auto _all               = _request.query().get("all").getOrElse("0");
+              auto _admin             = _request.query().get("admin-mode").getOrElse("0");
+              auto _recursive         = _request.query().get("recursive").getOrElse("0");
+
+              auto _src_resource      = _request.query().get("src-resource").getOrElse("");
+
+              // Int parameters
+              auto _thread_count       = _request.query().get("thread-count").getOrElse("");
+              auto _replica_number          = _request.query().get("replica-number").getOrElse("");
+
+              // String paramaeters
+              auto _dst_resource     = _request.query().get("dst-resource").getOrElse("");
+
+              // Required parameters
+              auto _logical_path      = _request.query().get("logical-path").getOrElse("");
+              rstrcpy(
+                _repl_input.objPath,
+                _logical_path.c_str(),
+                MAX_NAME_LEN
+              );
+
+	      irods::experimental::key_value_proxy kvp {_repl_input.condInput};
+
+              _is_collection = fscli::is_collection(
+                fscli::status(_conn, decode_url(_logical_path))
+              );
+
+              if ( ! _replica_number.empty() ) {
+		kvp[REPL_NUM_KW] = _replica_number.c_str();
+              }
+
+              if ( ! _thread_count.empty() ) {
+                _repl_input.numThreads = std::stoi(_thread_count);
+              } else {
+                _repl_input.numThreads = NO_THREADING;
+              }
+
+              if ( ! _dst_resource.empty() ) {
+		kvp[DEST_RESC_NAME_KW] = _dst_resource.c_str();
+              } else if (strlen( myRodsEnv.rodsDefResource ) > 0) {
+		kvp[DEST_RESC_NAME_KW] = myRodsEnv.rodsDefResource;
+              }
+
+              if ( is_set(_recursive) ) {
+		  kvp[RECURSIVE_OPR__KW] = "";
+              }
+
+              if ( is_set(_admin) ) {
+		kvp[ADMIN_KW] = "";
+              }
+
+              if ( is_set(_all) ) {
+		kvp[ALL_KW] = "";
+              }
+
+              char resc[MAX_NAME_LEN] = { '\0' };
+              if ( ! _dst_resource.empty() ) {
+                  strcpy(
+                    resc,
+                    _dst_resource.c_str()
+                  );
+              }
+
+              // If we didn't get a dest resource from the user,
+              // get it from the rods environment
+              if ( '\0' == resc[0] && strlen(myRodsEnv.rodsDefResource) > 0 ) {
+                  strcpy(
+                    resc,
+                    myRodsEnv.rodsDefResource
+                  );
+              }
+
+	      kvp[DEST_RESC_NAME_KW] = resc;
+        } // setup_args_for_repl
     }; // class logical_path_rename
 } // namespace irods::rest

--- a/irods_specific_implementation/utils.hpp
+++ b/irods_specific_implementation/utils.hpp
@@ -60,6 +60,11 @@ namespace irods::rest
 
         _response.send(http_code, msg);
     } // handle_request
+
+    inline bool is_set(const std::string_view s){
+        return s == "1"; // we only honor "1" for this client
+    } 
+
 } // namespace irods::rest
 
 #endif // IRODS_REST_CPP_UTILS_HPP

--- a/irods_specific_implementation/utils.hpp
+++ b/irods_specific_implementation/utils.hpp
@@ -61,9 +61,10 @@ namespace irods::rest
         _response.send(http_code, msg);
     } // handle_request
 
-    inline bool is_set(const std::string_view s){
+    inline bool is_set(const std::string_view s)
+    {
         return s == "1"; // we only honor "1" for this client
-    } 
+    }
 
 } // namespace irods::rest
 

--- a/irods_specific_implementation/utils.hpp
+++ b/irods_specific_implementation/utils.hpp
@@ -61,7 +61,7 @@ namespace irods::rest
         _response.send(http_code, msg);
     } // handle_request
 
-    inline bool is_set(const std::string_view s)
+    inline auto is_set(const std::string_view s) -> bool
     {
         return s == "1"; // we only honor "1" for this client
     }

--- a/packaging/irods_client_rest_cpp.json.template
+++ b/packaging/irods_client_rest_cpp.json.template
@@ -5,7 +5,8 @@
         "port": 1247,
         "ssl_negotiation_policy": "CS_NEG_REFUSE",
         "rodsadmin_username": "rods",
-        "rodsadmin_password": "rods"
+        "rodsadmin_password": "rods",
+        "default_resource": "demoResc"
     },
     "rest_api": {
         "jwt_signing_key": "TEMPORARY_SIGNING_KEY",

--- a/packaging/irods_rest.py
+++ b/packaging/irods_rest.py
@@ -55,6 +55,34 @@ def logical_path_rename(_token, _src, _dst):
 
     return body.decode('utf-8')
 
+def logical_path_replicate(_token, _logical_path, _admin=None, _all=None, _num_threads=None, _repl_num=None,
+         _recursive=None, _dst_resource=None,
+         _src_resource=None):
+    buffer = StringIO()
+    c = pycurl.Curl()
+    c.setopt(pycurl.HTTPHEADER,['Accept: application/json'])
+    c.setopt(pycurl.HTTPHEADER,['Authorization: '+_token])
+    c.setopt(c.CUSTOMREQUEST, 'POST')
+
+    url = '{0}/resource?logical-path={1}'.format(base_url(), _logical_path)
+
+    if _all          : url += '&all=1'
+    if _num_threads  :
+    if _recursive    : url += '&recursive=1'
+    if _repl_num     : url += '&replica-number={0}'.format(_repl_num)
+    if _src_resource : url += '&src-resource={0}'.format(_src_resource)
+    if _dst_resource : url += '&dst-resource={0}'.format(_dst_resource)
+
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEDATA, buffer)
+
+    c.perform()
+    c.close()
+
+    body = buffer.getvalue()
+
+    return body.decode('utf-8')
+
 def logical_path_delete(_token, _logical_path, _no_trash = None,
                         _recursive = None, _unregister = None):
     buffer = BytesIO()
@@ -66,6 +94,33 @@ def logical_path_delete(_token, _logical_path, _no_trash = None,
     if _no_trash: url += '&no-trash=1'
     if _unregister: url += '&unregister=1'
     if _recursive: url += '&recursive=1'
+
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEDATA, buffer)
+    c.perform()
+    c.close()
+
+    body = buffer.getvalue()
+
+    return body.decode('utf-8')
+
+def logical_path_trim(_token, _logical_path, _dryrun=None, _age=None, _repl_num=None, _src_resc=None, _num_copies=None,
+         _admin=None, _recursive=None):
+    buffer = StringIO()
+    c = pycurl.Curl()
+    c.setopt(pycurl.HTTPHEADER,['Accept: application/json'])
+    c.setopt(pycurl.HTTPHEADER,['Authorization: '+_token])
+    c.setopt(c.CUSTOMREQUEST, 'DELETE')
+
+    url = '{0}/resource?logical-path={1}'.format(base_url(), _logical_path)
+
+    if _admin          : url += '&admin=1'
+    if _dryrun         : url += '&dryrun=1'
+    if _recursive      : url += '&recursive=1'
+    if _age            : url += '&age={0}'.format(_age)
+    if _repl_num       : url += '&repl-num{0}'.format(_repl_num)
+    if _src_resc       : url += '&src-resc={0}'.format(_src_resc)
+    if _num            : url += '&num={0}'.format(_num)
 
     c.setopt(c.URL, url)
     c.setopt(c.WRITEDATA, buffer)

--- a/packaging/irods_rest.py
+++ b/packaging/irods_rest.py
@@ -58,20 +58,21 @@ def logical_path_rename(_token, _src, _dst):
 def logical_path_replicate(_token, _logical_path, _admin=None, _all=None, _num_threads=None, _repl_num=None,
          _recursive=None, _dst_resource=None,
          _src_resource=None):
-    buffer = StringIO()
+    buffer = BytesIO()
     c = pycurl.Curl()
     c.setopt(pycurl.HTTPHEADER,['Accept: application/json'])
     c.setopt(pycurl.HTTPHEADER,['Authorization: '+_token])
     c.setopt(c.CUSTOMREQUEST, 'POST')
 
-    url = '{0}/resource?logical-path={1}'.format(base_url(), _logical_path)
+    url = base_url()+f'logicalpath/replicate?logical-path={_logical_path}'
 
+    if _admin        : url += '&admin-mode=1'
     if _all          : url += '&all=1'
-    if _num_threads  :
+    if _num_threads  : url += f'&thread-count={_num_threads}'
     if _recursive    : url += '&recursive=1'
-    if _repl_num     : url += '&replica-number={0}'.format(_repl_num)
-    if _src_resource : url += '&src-resource={0}'.format(_src_resource)
-    if _dst_resource : url += '&dst-resource={0}'.format(_dst_resource)
+    if _repl_num     : url += f'&replica-number={_repl_num}'
+    if _src_resource : url += f'&src-resource={_src_resource}'
+    if _dst_resource : url += f'&dst-resource={_dst_resource}'
 
     c.setopt(c.URL, url)
     c.setopt(c.WRITEDATA, buffer)
@@ -104,23 +105,22 @@ def logical_path_delete(_token, _logical_path, _no_trash = None,
 
     return body.decode('utf-8')
 
-def logical_path_trim(_token, _logical_path, _dryrun=None, _age=None, _repl_num=None, _src_resc=None, _num_copies=None,
+def logical_path_trim(_token, _logical_path, _age=None, _repl_num=None, _src_resc=None, _num_copies=None,
          _admin=None, _recursive=None):
-    buffer = StringIO()
+    buffer = BytesIO()
     c = pycurl.Curl()
     c.setopt(pycurl.HTTPHEADER,['Accept: application/json'])
     c.setopt(pycurl.HTTPHEADER,['Authorization: '+_token])
-    c.setopt(c.CUSTOMREQUEST, 'DELETE')
+    c.setopt(c.CUSTOMREQUEST, 'POST')
 
-    url = '{0}/resource?logical-path={1}'.format(base_url(), _logical_path)
+    url = base_url()+f'logicalpath/trim?logical-path={_logical_path}'
 
-    if _admin          : url += '&admin=1'
-    if _dryrun         : url += '&dryrun=1'
+    if _admin          : url += '&admin-mode=1'
     if _recursive      : url += '&recursive=1'
-    if _age            : url += '&age={0}'.format(_age)
-    if _repl_num       : url += '&repl-num{0}'.format(_repl_num)
-    if _src_resc       : url += '&src-resc={0}'.format(_src_resc)
-    if _num            : url += '&num={0}'.format(_num)
+    if _age            : url += f'&minimum-age-in-minutes={_age}'
+    if _repl_num       : url += f'&replica-number={_repl_num}'
+    if _src_resc       : url += f'&src-resource={_src_resc}'
+    if _num_copies     : url += f'&minimum-number-of-remaining-replicas={_num_copies}'
 
     c.setopt(c.URL, url)
     c.setopt(c.WRITEDATA, buffer)


### PR DESCRIPTION
This PR adds ```repl``` and ```trim``` functionality through the ```/resource``` route. ```repl``` does not honor the ```restart file``` parameter until that parameter is better understood. Still writing tests and docs but wanted to create a PR for the purposes of getting this out into the world.