### PR TITLE
[#158] Bump minimum required CMake to 3.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12.0 FATAL_ERROR)
 
 find_package(IRODS 4.3.0 EXACT REQUIRED CONFIG)
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ $ mkdir build && cd build && cmake ..
 $ make -j package
 ```
 
+Note: For machines with fewer than 4 cores or heavy workloads, building using the `-j` option with `make` should be done with caution. Refer to the manual for more information on this topic: https://www.gnu.org/software/make/manual/make.html#Parallel-Execution
+
 ## Building with Docker
 
 This repository provides a Dockerfile with all of the tools needed to build a package for Ubuntu 20.04.


### PR DESCRIPTION
Also, add a note to the README about building with -j option for make.

---

3.12.0 was chosen because it matches the minimum requirement for building iRODS, from which we borrow several CMake modules. It has been demonstrated that 3.21.0 is sufficient and 3.10.0 is not.