### PR TITLE
[#165] /logicalpath: Add POST operation for mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,29 @@ A JSON structured response within the body containing the listing, or an iRODS e
 ```
 
 ### /logicalpath
-Deletes a data object or a collection.
+Interactions for paths within the iRODS logical namespace.
+
+**Method** POST
+
+Create an entity in the iRODS logical namespace.
+
+**Parameters**
+- logical-path: The absolute path leading to the data object or collection to be created.
+- collection: Indicates that a collection is being created. Defaults to "0".
+- create-parent-collections: Indicates that parent collections of the destination collection should be created if necessary. Only applicable when `&collection=1` is used. Defaults to "0".
+
+**Example CURL command**
+```
+# Equivalent to: imkdir -p /tempZone/home/rods/a/b/c
+curl -X POST -H "Authorization: ${TOKEN}" "http://localhost/irods-rest/0.9.2/logicalpath?logical-path=/tempZone/home/rods/a/b/c&collection=1&create-parent-collections=1"
+```
+
+**Returns**
+Nothing on success.
 
 **Method** DELETE
+
+Deletes a data object or a collection.
 
 **Parameters**
 - logical-path: The absolute path leading to the data object or collection to be deleted.

--- a/api/LogicalPathApi.cpp
+++ b/api/LogicalPathApi.cpp
@@ -35,6 +35,8 @@ namespace io::swagger::server::api
     {
         using namespace Pistache::Rest;
 
+        Routes::Post(
+            router, irods::rest::base_url + "/logicalpath", Routes::bind(&LogicalPathApi::post_handler, this));
         Routes::Delete(
             router, irods::rest::base_url + "/logicalpath", Routes::bind(&LogicalPathApi::delete_handler, this));
         Routes::Post(
@@ -64,6 +66,16 @@ namespace io::swagger::server::api
     {
         try {
             this->delete_handler_impl(request, response);
+        }
+        catch (const std::runtime_error& e) {
+            response.send(Pistache::Http::Code::Bad_Request, e.what());
+        }
+    }
+
+    void LogicalPathApi::post_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
+    {
+        try {
+            this->post_handler_impl(request, response);
         }
         catch (const std::runtime_error& e) {
             response.send(Pistache::Http::Code::Bad_Request, e.what());

--- a/api/LogicalPathApi.h
+++ b/api/LogicalPathApi.h
@@ -30,11 +30,15 @@ namespace io::swagger::server::api
 
         void default_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
 
+        void post_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
         void delete_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
         void rename_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
         void trim_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
         void replicate_handler(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response);
 
+        virtual void post_handler_impl(
+            const Pistache::Rest::Request& request,
+            Pistache::Http::ResponseWriter& response) = 0;
         virtual void delete_handler_impl(
             const Pistache::Rest::Request& request,
             Pistache::Http::ResponseWriter& response) = 0;

--- a/impl/LogicalPathApiImpl.cpp
+++ b/impl/LogicalPathApiImpl.cpp
@@ -14,6 +14,15 @@ namespace io::swagger::server::api
     {
     }
 
+    void LogicalPathApiImpl::post_handler_impl(const Pistache::Rest::Request& request,
+                                               Pistache::Http::ResponseWriter& response)
+    {
+        const auto irods_logic = [this](const Pistache::Rest::Request& _req, Pistache::Http::ResponseWriter& _res) {
+            return irods_logical_path_.post_dispatcher(_req, _res);
+        };
+        irods::rest::handle_request(irods_logic, request, response);
+    }
+
     void LogicalPathApiImpl::delete_handler_impl(const Pistache::Rest::Request& request,
                                                  Pistache::Http::ResponseWriter& response)
     {

--- a/impl/LogicalPathApiImpl.h
+++ b/impl/LogicalPathApiImpl.h
@@ -28,6 +28,9 @@ namespace io::swagger::server::api
         void rename_handler_impl(const Pistache::Rest::Request& request,
                                  Pistache::Http::ResponseWriter& response) override;
 
+        void post_handler_impl(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter& response)
+            override;
+
         void delete_handler_impl(const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter& response)
             override;
 

--- a/packaging/irods_rest.py
+++ b/packaging/irods_rest.py
@@ -404,6 +404,28 @@ def query(_token, _string, _limit, _offset, _type, _case_sensitive='1', _distinc
 
     return body.decode('utf-8')
 
+def logical_path_post(_token,
+                      _logical_path,
+                      _collection = None,
+                      _create_parent_collections = None):
+    buffer = BytesIO()
+    c = pycurl.Curl()
+    c.setopt(pycurl.HTTPHEADER,['Authorization: ' + _token])
+    c.setopt(c.CUSTOMREQUEST, 'POST')
+
+    url = base_url()+f'logicalpath?logical-path={_logical_path}'
+    if _collection: url += f'&collection={_collection}'
+    if _create_parent_collections: url += f'&create-parent-collections={_create_parent_collections}'
+
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEDATA, buffer)
+    c.perform()
+    c.close()
+
+    body = buffer.getvalue()
+
+    return body.decode('utf-8')
+
 def get_arguments():
     full_args = sys.argv
     arg_list  = full_args[1:]


### PR DESCRIPTION
Adds a POST function for the /logicalpath endpoint which creates a
collection a la imkdir. If the collection parameter is not used, this
operation does nothing.